### PR TITLE
Add game samples for WoW, CS2, and Rocket League

### DIFF
--- a/apps/web/app/[tenant]/page.tsx
+++ b/apps/web/app/[tenant]/page.tsx
@@ -16,12 +16,33 @@ export default function TenantHome({ params }: Params) {
         <p className="mt-6 max-w-2xl text-lg text-white/80">
           Multi-tenant, ultra-advanced, graphic wiki system for any game and any site. This is a demo instance.
         </p>
-        <div className="mt-8 flex gap-4">
+        <div className="mt-8 flex flex-wrap gap-4">
           <Link href={`/${tenant}/games/stellar-odyssey`} className="rounded-xl bg-brand px-5 py-3 font-semibold text-white shadow-lg shadow-brand/30 hover:opacity-90 transition">
             View Demo Game
           </Link>
           <Link href={`/${tenant}/pages/stellar-odyssey/intro`} className="rounded-xl bg-accent px-5 py-3 font-semibold text-black hover:opacity-90 transition">
             Read Intro Page
+          </Link>
+
+          <Link href={`/${tenant}/games/world-of-warcraft`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            World of Warcraft
+          </Link>
+          <Link href={`/${tenant}/pages/world-of-warcraft/intro`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            WoW Intro
+          </Link>
+
+          <Link href={`/${tenant}/games/counter-strike-2`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            Counter-Strike 2
+          </Link>
+          <Link href={`/${tenant}/pages/counter-strike-2/intro`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            CS2 Intro
+          </Link>
+
+          <Link href={`/${tenant}/games/rocket-league`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            Rocket League
+          </Link>
+          <Link href={`/${tenant}/pages/rocket-league/intro`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            Rocket League Intro
           </Link>
         </div>
       </section>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -25,12 +25,33 @@ export default function Home() {
         <p className="mt-6 max-w-2xl text-lg text-white/80">
           Multi-tenant, ultra-advanced, graphic wiki system for any game and any site. This is a demo instance.
         </p>
-        <div className="mt-8 flex gap-4">
+        <div className="mt-8 flex flex-wrap gap-4">
           <Link href={`/${tenant}/games/stellar-odyssey`} className="rounded-xl bg-brand px-5 py-3 font-semibold text-white shadow-lg shadow-brand/30 hover:opacity-90 transition">
             View Demo Game
           </Link>
           <Link href={`/${tenant}/pages/stellar-odyssey/intro`} className="rounded-xl bg-accent px-5 py-3 font-semibold text-black hover:opacity-90 transition">
             Read Intro Page
+          </Link>
+
+          <Link href={`/${tenant}/games/world-of-warcraft`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            World of Warcraft
+          </Link>
+          <Link href={`/${tenant}/pages/world-of-warcraft/intro`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            WoW Intro
+          </Link>
+
+          <Link href={`/${tenant}/games/counter-strike-2`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            Counter-Strike 2
+          </Link>
+          <Link href={`/${tenant}/pages/counter-strike-2/intro`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            CS2 Intro
+          </Link>
+
+          <Link href={`/${tenant}/games/rocket-league`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            Rocket League
+          </Link>
+          <Link href={`/${tenant}/pages/rocket-league/intro`} className="rounded-xl bg-white/10 px-5 py-3 font-semibold hover:bg-white/20 transition">
+            Rocket League Intro
           </Link>
         </div>
       </section>

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -45,6 +45,135 @@ async function main() {
       }
     }
   })
+
+  // World of Warcraft
+  const wow = await prisma.game.upsert({
+    where: { tenantId_slug: { tenantId: tenant.id, slug: 'world-of-warcraft' } },
+    update: {},
+    create: {
+      tenantId: tenant.id,
+      slug: 'world-of-warcraft',
+      title: 'World of Warcraft',
+      summary: 'A massively multiplayer online role-playing game set in the world of Azeroth.',
+      coverUrl: 'https://images.unsplash.com/photo-1520975916090-3105956dac38?q=80&w=1600&auto=format&fit=crop',
+      bannerUrl: 'https://images.unsplash.com/photo-1542751371-adc38448a05e?q=80&w=2400&auto=format&fit=crop',
+      developers: ['Blizzard Entertainment'],
+      publishers: ['Blizzard Entertainment'],
+      platforms: ['PC'],
+      genres: ['MMORPG', 'Fantasy'],
+      releaseDate: new Date('2004-11-23')
+    }
+  })
+
+  await prisma.page.upsert({
+    where: { tenantId_slug: { tenantId: tenant.id, slug: 'world-of-warcraft/intro' } },
+    update: {},
+    create: {
+      tenantId: tenant.id,
+      gameId: wow.id,
+      slug: 'world-of-warcraft/intro',
+      title: 'Introduction',
+      summary: 'Start here to learn the basics of World of Warcraft.',
+      content: {
+        type: 'doc',
+        content: [
+          { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Welcome to World of Warcraft' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'This wiki covers classes, professions, raids, and more.' }] },
+          { type: 'bulletList', content: [
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'New Player Guide' }] }] },
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Leveling Tips' }] }] },
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Dungeons & Raids' }] }] }
+          ]}
+        ]
+      }
+    }
+  })
+
+  // Counter-Strike 2
+  const cs2 = await prisma.game.upsert({
+    where: { tenantId_slug: { tenantId: tenant.id, slug: 'counter-strike-2' } },
+    update: {},
+    create: {
+      tenantId: tenant.id,
+      slug: 'counter-strike-2',
+      title: 'Counter-Strike 2',
+      summary: 'The next era of tactical FPS built on the Source 2 engine.',
+      coverUrl: 'https://images.unsplash.com/photo-1542831371-29b0f74f9713?q=80&w=1600&auto=format&fit=crop',
+      bannerUrl: 'https://images.unsplash.com/photo-1607252650355-f7fd0460ccdb?q=80&w=2400&auto=format&fit=crop',
+      developers: ['Valve'],
+      publishers: ['Valve'],
+      platforms: ['PC'],
+      genres: ['FPS', 'Shooter'],
+      releaseDate: new Date('2023-09-27')
+    }
+  })
+
+  await prisma.page.upsert({
+    where: { tenantId_slug: { tenantId: tenant.id, slug: 'counter-strike-2/intro' } },
+    update: {},
+    create: {
+      tenantId: tenant.id,
+      gameId: cs2.id,
+      slug: 'counter-strike-2/intro',
+      title: 'Introduction',
+      summary: 'Start here to learn the basics of CS2.',
+      content: {
+        type: 'doc',
+        content: [
+          { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Welcome to Counter-Strike 2' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'This wiki covers maps, weapons, economy, and competitive play.' }] },
+          { type: 'bulletList', content: [
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Beginner Loadouts' }] }] },
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Map Callouts' }] }] },
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Economy Guide' }] }] }
+          ]}
+        ]
+      }
+    }
+  })
+
+  // Rocket League
+  const rl = await prisma.game.upsert({
+    where: { tenantId_slug: { tenantId: tenant.id, slug: 'rocket-league' } },
+    update: {},
+    create: {
+      tenantId: tenant.id,
+      slug: 'rocket-league',
+      title: 'Rocket League',
+      summary: 'High-powered hybrid of arcade soccer and vehicular mayhem!',
+      coverUrl: 'https://images.unsplash.com/photo-1520975916090-3105956dac38?q=80&w=1600&auto=format&fit=crop',
+      bannerUrl: 'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?q=80&w=2400&auto=format&fit=crop',
+      developers: ['Psyonix'],
+      publishers: ['Psyonix'],
+      platforms: ['PC', 'PlayStation', 'Xbox', 'Nintendo Switch'],
+      genres: ['Sports', 'Action', 'Racing'],
+      releaseDate: new Date('2015-07-07')
+    }
+  })
+
+  await prisma.page.upsert({
+    where: { tenantId_slug: { tenantId: tenant.id, slug: 'rocket-league/intro' } },
+    update: {},
+    create: {
+      tenantId: tenant.id,
+      gameId: rl.id,
+      slug: 'rocket-league/intro',
+      title: 'Introduction',
+      summary: 'Start here to learn the basics of Rocket League.',
+      content: {
+        type: 'doc',
+        content: [
+          { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Welcome to Rocket League' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'This wiki covers car presets, mechanics, and ranked play.' }] },
+          { type: 'bulletList', content: [
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Beginner Mechanics' }] }] },
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Positioning Basics' }] }] },
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Training Packs' }] }] }
+          ]}
+        ]
+      }
+    }
+  })
 }
 
 main().then(() => process.exit(0)).catch((e) => {


### PR DESCRIPTION
Adds sample data for World of Warcraft, Counter-Strike 2, and Rocket League, and links them on the homepages.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ec581c9-97d1-4ef8-ab9d-7a2569a9a40e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ec581c9-97d1-4ef8-ab9d-7a2569a9a40e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

